### PR TITLE
Align timezone to Europe/Paris to match production settings

### DIFF
--- a/_php/timezone.ini
+++ b/_php/timezone.ini
@@ -1,1 +1,1 @@
-date.timezone = Europe/London
+date.timezone = Europe/Paris


### PR DESCRIPTION
@FolkenFR 
I had an issue on my development environment: inventories created in DCC using a correlation were not fetched in the trends dashboard.
After looking at the settings, it appears that Mysql is defined to use the system timezone 
(SELECT @@ global. time_zone) which is for us Europe/Paris but the PHP here is set on Europe/London. When performing some queries based on datetimes using PHP and provide timezone aware dates using DateTime::ATOM, we end up with a difference of 1h.
After looking at the production settings, we have Europe/Paris both set on the system and in php.ini. This PR aims to align the settings on development env too.

A more long term solution would be to always save dates as UTC in the database and have a conversion layer on the application side that would perform the transformation back and forth based on timezone settings.
